### PR TITLE
PersonalRecord モデルとマイグレーション追加

### DIFF
--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -19,4 +19,9 @@ class Exercise extends Model
     {
         return $this->belongsTo(BodyPart::class);
     }
+
+    public function personalRecords()
+    {
+        return $this->hasMany(PersonalRecord::class);
+    }
 }

--- a/app/Models/PersonalRecord.php
+++ b/app/Models/PersonalRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PersonalRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'exercise_id',
+        'value',
+        'unit',
+        'achieved_date',
+        'notes',
+    ];
+
+    protected $casts = [
+        'achieved_date' => 'date',
+        'value' => 'float',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function exercise()
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,4 +44,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function personalRecords()
+    {
+        return $this->hasMany(PersonalRecord::class);
+    }
 }

--- a/database/factories/PersonalRecordFactory.php
+++ b/database/factories/PersonalRecordFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PersonalRecord>
+ */
+class PersonalRecordFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'exercise_id' => Exercise::factory(),
+            'value' => $this->faker->randomFloat(2, 1, 500),
+            'unit' => $this->faker->randomElement(['kg', 'lbs']),
+            'achieved_date' => $this->faker->dateTimeBetween('-1 year', 'now'),
+            'notes' => $this->faker->optional(0.7)->sentence,
+        ];
+    }
+}

--- a/database/migrations/2025_03_16_140157_create_personal_records_table.php
+++ b/database/migrations/2025_03_16_140157_create_personal_records_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('exercise_id')->constrained('exercises');
+            $table->float('value');
+            $table->string('unit')->default('kg');
+            $table->date('achieved_date');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_records');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,9 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+        
+        $this->call([
+            PersonalRecordSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/PersonalRecordSeeder.php
+++ b/database/seeders/PersonalRecordSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Exercise;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class PersonalRecordSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $user = User::first() ?? User::factory()->create();
+        $exercises = Exercise::take(3)->get();
+        
+        if ($exercises->isEmpty()) {
+            $exercises = Exercise::factory(3)->create();
+        }
+        
+        foreach ($exercises as $exercise) {
+            // Create sample personal records with progressively improving performance
+            PersonalRecord::factory()->count(5)->create([
+                'user_id' => $user->id,
+                'exercise_id' => $exercise->id,
+                'achieved_date' => now()->subDays(rand(1, 180)),
+            ]);
+            
+            // Create a current personal best
+            PersonalRecord::factory()->create([
+                'user_id' => $user->id,
+                'exercise_id' => $exercise->id,
+                'value' => rand(100, 200),
+                'achieved_date' => now()->subDays(rand(0, 10)),
+                'notes' => 'Current personal best!'
+            ]);
+        }
+    }
+}

--- a/tests/Unit/Models/PersonalRecordTest.php
+++ b/tests/Unit/Models/PersonalRecordTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Exercise;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PersonalRecordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_personal_record_belongs_to_user()
+    {
+        $personalRecord = PersonalRecord::factory()->create();
+        $this->assertInstanceOf(User::class, $personalRecord->user);
+    }
+
+    public function test_personal_record_belongs_to_exercise()
+    {
+        $personalRecord = PersonalRecord::factory()->create();
+        $this->assertInstanceOf(Exercise::class, $personalRecord->exercise);
+    }
+
+    public function test_personal_record_has_correct_fillable_attributes()
+    {
+        $personalRecord = new PersonalRecord();
+        $expectedFillable = [
+            'user_id',
+            'exercise_id',
+            'value',
+            'unit',
+            'achieved_date',
+            'notes',
+        ];
+        
+        $this->assertEquals($expectedFillable, $personalRecord->getFillable());
+    }
+
+    public function test_date_is_cast_correctly()
+    {
+        $personalRecord = PersonalRecord::factory()->create([
+            'achieved_date' => '2023-01-15'
+        ]);
+        
+        $this->assertIsObject($personalRecord->achieved_date);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $personalRecord->achieved_date);
+    }
+}


### PR DESCRIPTION
- PersonalRecordモデル、マイグレーション、ファクトリーを実装
- UserとExerciseモデルに関連を追加
- テストとシーダーを追加

🤖 Generated with [Claude Code](https://claude.ai/code)

![image](https://github.com/user-attachments/assets/a1448010-7960-4522-aeeb-98a8b425b539)
